### PR TITLE
Ensure PID is an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Ensure PID is an integer (https://github.com/schneems/get_process_mem/pull/46)
+
 ## 0.2.7
 
 - Native (faster) support for returning memory from different PIDs on mac (https://github.com/schneems/get_process_mem/pull/42)

--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -48,7 +48,7 @@ class GetProcessMem
   def initialize(pid = Process.pid)
     @status_file  = Pathname.new "/proc/#{pid}/status"
     @process_file = Pathname.new "/proc/#{pid}/smaps"
-    @pid          = pid
+    @pid          = Integer(pid)
     @linux        = @status_file.exist?
   end
 

--- a/test/get_process_mem_test.rb
+++ b/test/get_process_mem_test.rb
@@ -15,6 +15,15 @@ class GetProcessMemTest < Test::Unit::TestCase
     Process.wait(pid) if pid
   end
 
+  def test_invalid_pid
+    raised_exception = false
+    GetProcessMem.new('ls')
+  rescue ArgumentError
+    raised_exception = true
+  ensure
+    assert raised_exception
+  end
+
   def test_seems_to_work
     assert @mem.kb    > 0
     assert @mem.mb    > 0

--- a/test/get_process_mem_test.rb
+++ b/test/get_process_mem_test.rb
@@ -17,7 +17,7 @@ class GetProcessMemTest < Test::Unit::TestCase
 
   def test_invalid_pid
     raised_exception = false
-    GetProcessMem.new('ls')
+    GetProcessMem.new("ls")
   rescue ArgumentError
     raised_exception = true
   ensure


### PR DESCRIPTION
This ensures that the `ps` call doesn't invoke something else.